### PR TITLE
Update entity_provider.rst

### DIFF
--- a/cookbook/security/entity_provider.rst
+++ b/cookbook/security/entity_provider.rst
@@ -446,7 +446,7 @@ Il codice successivo mostra l'implementazione di
                     'Impossibile trovare un oggetto AcmeUserBundle:User identificato da  "%s".',
                     $username
                 );
-                throw new UsernameNotFoundException($message, null, 0, $e);
+                throw new UsernameNotFoundException($message, 0, $e);
             }
 
             return $user;


### PR DESCRIPTION
Corretta la chiamata all'eccezione UsernameNotFoundException che causa un Fatal Error.
UsernameNotFoundException accetta solo 3 parametri nel costruttore.
\Exception ([ string $message = "" [, int $code = 0 [, Exception $previous = NULL ]]] )
