### PR TITLE
Fix method "getTotalTime" to "getDuration".

### DIFF
--- a/cookbook/testing/profiling.rst
+++ b/cookbook/testing/profiling.rst
@@ -39,7 +39,7 @@ predefinita in ambiente ``test``)::
                 // verifica il tempo speso nel framework
                 $this->assertLessThan(
                     500,
-                    $profile->getCollector('time')->getTotalTime()
+                    $profile->getCollector('time')->getDuration()
                 );
             }
         }


### PR DESCRIPTION
See http://symfony.com/doc/current/cookbook/testing/profiling.html and http://api.symfony.com/2.3/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.html#method_getDuration
