### PR TITLE
Correzione nomi campi pdo_session_storage.rst

### DIFF
--- a/cookbook/configuration/pdo_session_storage.rst
+++ b/cookbook/configuration/pdo_session_storage.rst
@@ -178,7 +178,7 @@ simile alla seguente (MySQL):
         `id_sessione` varchar(255) NOT NULL,
         `valore_sessione` text NOT NULL,
         `tempo_sessione` int(11) NOT NULL,
-        PRIMARY KEY (`session_id`)
+        PRIMARY KEY (`id_sessione`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 PostgreSQL
@@ -192,7 +192,7 @@ Per PostgreSQL, la dichiarazione sarà simile alla seguente:
         id_sessione character varying(255) NOT NULL,
         valore_sessione text NOT NULL,
         tempo_sessione integer NOT NULL,
-        CONSTRAINT session_pkey PRIMARY KEY (session_id),
+        CONSTRAINT session_pkey PRIMARY KEY (id_sessione),
     );
 
 Microsoft SQL Server
@@ -207,7 +207,7 @@ Per MSSQL, l'istruzione potrebbe essere come la seguente:
 	    [valore_sessione] [ntext] NOT NULL,
         [tempo_sessione] [int] NOT NULL,
 		PRIMARY KEY CLUSTERED(
-			[session_id] ASC
+			[id_sessione] ASC
 		) WITH (
 		    PAD_INDEX  = OFF,
 		    STATISTICS_NORECOMPUTE  = OFF,


### PR DESCRIPTION
Ho corretto una incoerenza tra i nomi dei campi; in alcuni punti era rimasto l'originale inglese.
