### PR TITLE
Replaced "form_widget" by "form_row" in collection example

### DIFF
--- a/reference/forms/types/collection.rst
+++ b/reference/forms/types/collection.rst
@@ -160,7 +160,7 @@ ulteriormente, perché l'attributo ``data-prototype`` viene reso automaticamente
             {# ... #}
 
             {# memorizza il prototipo nell'attributo data-prototype #}
-            <ul id="email-fields-list" data-prototype="{{ form_widget(form.emails.vars.prototype) | e }}">
+            <ul id="email-fields-list" data-prototype="{{ form_row(form.emails.vars.prototype) | e }}">
             {% for emailField in form.emails %}
                 <li>
                     {{ form_errors(emailField) }}


### PR DESCRIPTION
Hi,

This is a port of this PR: https://github.com/symfony/symfony-docs/pull/5133

I copy-paste the description below, but I guess all discussion should happen there, and we should wait on that one.

> In the Form reference documentation, for the collection field, an example is given about rendering the prototype.
> But form_widgetTwig function is used instead of form_row. This is a bad advice in my opinion, as rendered HTML is then different than the one for an already here field. In example, we will be missing the label.
> 
> The small fix change the function used.
