### PR TITLE
Add EditorConfig File. Config file for phpstorm plugin to format code…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.{rst,rst.inc}]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Add EditorConfig File. Config file for phpstorm plugin to format code standard: https://plugins.jetbrains.com/plugin/7294

I did a copy and paste from here: 
https://github.com/symfony/symfony-docs/blob/2.7/.editorconfig

| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |
